### PR TITLE
`docker kill` does not have `-f` option

### DIFF
--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -106,7 +106,7 @@ if [ -f "$JOBFILE" ]; then
 fi
 
 dclear () {
-    docker ps -a -q | xargs docker kill -f
+    docker ps -a -q | xargs docker kill
     docker ps -a -q | xargs docker rm -f
     docker images | grep "api\|none" | awk '{print $3}' | xargs docker rmi -f
     docker volume prune -f


### PR DESCRIPTION
$ docker kill --help

```
Usage:  docker kill [OPTIONS] CONTAINER [CONTAINER...]

Kill one or more running containers

Aliases:
  docker container kill, docker kill

Options:
  -s, --signal string   Signal to send to the container
```